### PR TITLE
Fix #1 add output of opam env to environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # OCaml Expect and Inline Test Explorer for Visual Studio Code Changelog
 
+## Version 0.3.0 (2023-03-18)
+
+- Add error message window if `dune` does not work in a workspace.
+
+## Bugfixes
+
+- Use the current Opam environment to be able to use local executables like `dune`. See [#1](https://github.com/Release-Candidate/vscode-ocaml-expect-inline/issues/1)
+
+### Internal Changes
+
+- Add tests to check the parsing of `opam env`.
+
 ## Version 0.2.0 (2023-03-06)
 
 - Remove unnecessary node 'Expect and Inline Tests' in the Test Explorer tree.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-ocaml-expect-inline",
     "displayName": "OCaml Expect and Inline Tests",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "preview": false,
     "publisher": "release-candidate",
     "description": "Support for OCaml Expect PPX and inline PPX tests.",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,6 +55,16 @@ export function workspaceLabel(id: string) {
 export const testSourceGlob = "**/*.ml";
 
 /**
+ * Command to run Opam with.
+ */
+export const opamCmd = "opam";
+
+/**
+ * The arguments to pass to the opam command to get the current environment.
+ */
+export const opamEnvArg = ["env"];
+
+/**
  ******************************************************************************
  *  Test runner constants.
  * The test runner's command line is like this:

--- a/src/list_tests.ts
+++ b/src/list_tests.ts
@@ -52,8 +52,13 @@ export async function addTests(
  * Explorer tree.
  */
 async function addWorkspaceTests(env: h.Env, root: vscode.WorkspaceFolder) {
+    await setOpamEnv(root, env);
+
     // eslint-disable-next-line @typescript-eslint/no-extra-parens
     if (!(await h.isDuneWorking(root, env))) {
+        vscode.window.showWarningMessage(
+            `Error: Dune command 'dune' is not working in ${root.name}.\nSee the 'Output' window view of 'Alcotest Tests' for details.`
+        );
         return [];
     }
 
@@ -82,6 +87,18 @@ async function addWorkspaceTests(env: h.Env, root: vscode.WorkspaceFolder) {
             c.workspaceLabel(root.name),
             root.uri
         );
+    }
+}
+
+/**
+ * Run `opam env`, parse its output and set the environment accordingly.
+ * @param root The working directory for `opam`.
+ */
+async function setOpamEnv(root: vscode.WorkspaceFolder, env: h.Env) {
+    const opamEnv = await io.opamEnv(root);
+    for (const oEnv of opamEnv) {
+        process.env[oEnv.name] = oEnv.value;
+        env.outChannel.appendLine(`Adding env: ${oEnv.name} ${oEnv.value}`);
     }
 }
 

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -37,6 +37,14 @@ const versionRegex =
     /^[\s]*[vV]?(?:ersion)?\s*(?<version>[\p{N}][\p{N}\p{P}~]*)[\s]*$/mu;
 
 /**
+ * Regexp to parse the output of `opam env`.
+ * The name of the environment variable is saved in match group `name`, the
+ * value in match group `value`.
+ */
+const opamEnvRegex =
+    /^(?:[sS][Ee][Tt]x?\s*)?(?<name>\w+)[=\s]['"](?<value>[^'"]+)['"]/gmu;
+
+/**
  * Regexp to match a lock error message of dune.
  */
 const duneLockError =
@@ -160,6 +168,29 @@ export function escapeRegex(s: string) {
  */
 export function isCompileError(s: string) {
     return Boolean(s.match(compileError));
+}
+
+/**
+ * Parse the string `s` for environment variables.
+ * Like for example the output of `opam env`.
+ * @param s The string to parse.
+ * @returns A list of environment variables and their values: `[{ name, value}]`
+ */
+export function parseOpamEnv(s: string) {
+    const matches = s.matchAll(opamEnvRegex);
+    const env: { name: string; value: string }[] = [];
+    if (!s?.length) {
+        return env;
+    }
+    for (const match of matches) {
+        const name = match.groups?.name;
+        const value = match.groups?.value;
+        if (name && value) {
+            env.push({ name, value });
+        }
+    }
+
+    return env;
 }
 
 /**

--- a/test/fixtures/opamenv_tests.ts
+++ b/test/fixtures/opamenv_tests.ts
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (C) 2023 Roland Csaszar
+ *
+ * Project:  vscode-ocaml-alcotest-test-adapter
+ * File:     opamenv_tests.ts
+ * Date:     18.Mar.2023
+ *
+ * ==============================================================================
+ * Possible outputs of `opam env` and the expected results.
+ */
+
+/**
+ * Output of `opam env` on unix like systems.
+ */
+export const opamEnvUnixish = `OPAM_SWITCH_PREFIX='/Users/user name/.opam/5.0.0'; export OPAM_SWITCH_PREFIX;
+CAML_LD_LIBRARY_PATH='/home/somebody/.opam/5.0.0/lib/stublibs:/home/somebody/.opam/5.0.0/lib/ocaml/stublibs:/home/somebody/.opam/5.0.0/lib/ocaml'; export CAML_LD_LIBRARY_PATH;
+OCAML_TOPLEVEL_PATH='/Users/user name/.opam/5.0.0/lib/toplevel'; export OCAML_TOPLEVEL_PATH;
+PKG_CONFIG_PATH='/home/somebody/.opam/5.0.0/lib/pkgconfig:/home/somebody/.opam/5.0.0/lib/pkgconfig:'; export PKG_CONFIG_PATH;
+PATH='/Users/user name/.opam/5.0.0/bin:/bin:/usr/bin:/usr/local/bin'; export PATH;`;
+
+/**
+ * The expected result of parsing `opamEnvUnixish`.
+ */
+export const opamEnvUnixishObject = [
+    { name: "OPAM_SWITCH_PREFIX", value: "/Users/user name/.opam/5.0.0" },
+    {
+        name: "CAML_LD_LIBRARY_PATH",
+        value: "/home/somebody/.opam/5.0.0/lib/stublibs:/home/somebody/.opam/5.0.0/lib/ocaml/stublibs:/home/somebody/.opam/5.0.0/lib/ocaml",
+    },
+    {
+        name: "OCAML_TOPLEVEL_PATH",
+        value: "/Users/user name/.opam/5.0.0/lib/toplevel",
+    },
+    {
+        name: "PKG_CONFIG_PATH",
+        value: "/home/somebody/.opam/5.0.0/lib/pkgconfig:/home/somebody/.opam/5.0.0/lib/pkgconfig:",
+    },
+    {
+        name: "PATH",
+        value: "/Users/user name/.opam/5.0.0/bin:/bin:/usr/bin:/usr/local/bin",
+    },
+];
+
+/**
+ * Some Windows style environment definitions.
+ */
+export const opamEnvWin = `SET OPAM_SWITCH_PREFIX="C:\\opam\\switch"
+setx CAML_LD_LIBRARY_PATH "C:\\some path1;C:\\some other path"
+set OCAML_TOPLEVEL_PATH="c:\\toplevel1;c:\\toplvel2"
+setx PKG_CONFIG_PATH "C:\\package config\\path"
+SET PATH="C:\\Windows;C:\\ocaml\\bin"`;
+
+/**
+ * The expected result of parsing `opamEnvUnixish`.
+ */
+export const opamEnvWinObject = [
+    { name: "OPAM_SWITCH_PREFIX", value: "C:\\opam\\switch" },
+    {
+        name: "CAML_LD_LIBRARY_PATH",
+        value: "C:\\some path1;C:\\some other path",
+    },
+    {
+        name: "OCAML_TOPLEVEL_PATH",
+        value: "c:\\toplevel1;c:\\toplvel2",
+    },
+    {
+        name: "PKG_CONFIG_PATH",
+        value: "C:\\package config\\path",
+    },
+    {
+        name: "PATH",
+        value: "C:\\Windows;C:\\ocaml\\bin",
+    },
+];

--- a/test/parsing-test.ts
+++ b/test/parsing-test.ts
@@ -13,6 +13,7 @@
 import * as chai from "chai";
 import * as duneTests from "./fixtures/dune_tests";
 import * as mocha from "mocha";
+import * as opamEnvTests from "./fixtures/opamenv_tests";
 import * as parse from "../src/parsing";
 import * as testErrors from "./fixtures/test_errors";
 import * as testLists from "./fixtures/test_lists";
@@ -232,6 +233,37 @@ mocha.describe("Parsing Functions", () => {
             chai.assert.isTrue(
                 parse.isOCamlFile("fd a/ds ad/fg hs jdi.ml"),
                 "fd a/ds ad/fg hs jdi.ml -> true"
+            );
+        });
+    });
+    //==========================================================================
+    mocha.describe("parseOpamEnv", () => {
+        mocha.it("Empty string -> []", () => {
+            chai.assert.deepEqual(
+                parse.parseOpamEnv(""),
+                [],
+                "Empty string -> []"
+            );
+        });
+        mocha.it("No environment vars -> []", () => {
+            chai.assert.deepEqual(
+                parse.parseOpamEnv("hugo=fasfasf\n'hfdaliehfal'"),
+                [],
+                "No environment vars -> []"
+            );
+        });
+        mocha.it("Unix env vars -> env vars", () => {
+            chai.assert.deepEqual(
+                parse.parseOpamEnv(opamEnvTests.opamEnvUnixish),
+                opamEnvTests.opamEnvUnixishObject,
+                "opamEnvUnixish -> opamEnvUnixishObject"
+            );
+        });
+        mocha.it("Windows env vars -> env vars", () => {
+            chai.assert.deepEqual(
+                parse.parseOpamEnv(opamEnvTests.opamEnvWin),
+                opamEnvTests.opamEnvWinObject,
+                "opamEnvWin -> opamEnvWinObject"
             );
         });
     });


### PR DESCRIPTION
- Use the current Opam environment - the output of `opam env` - to be able to use local executables like `dune`.
- Add error message window if `dune` does not work in a workspace.
- Add tests to check the parsing of `opam env`.

See #1 