### PR TITLE
Fix bug if more than one test runner exists

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -64,6 +64,12 @@
 			"task": "test",
 			"problemMatcher": [],
 			"label": "yarn: test"
+		},
+		{
+			"type": "yarn",
+			"task": "compile",
+			"problemMatcher": [],
+			"label": "yarn: compile"
 		}
 	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # OCaml Expect and Inline Test Explorer for Visual Studio Code Changelog
 
+## Version 0.4.0 (2023-03-20)
+
+- New configuration values:
+  - `expectppx.discoverInSources` - Whether to parse source files on open and save for tests and update the Test Explorer tree. Should be set to `true` if `expectppx.discoverOnStartup` is `false`.
+  - `expectppx.dunePath` - Set an absolute path or a path relative to the project root of the Dune executable. Default: `dune` - use the one in the local Opam environment or in `PATH`. See [Issue #3](https://github.com/Release-Candidate/vscode-ocaml-expect-inline/issues/3).
+  - `expectppx.excludeRunners` - A list of inline test runner names to be excluded from test discovery an startup or refresh, e.g. because they take too long to finish.
+- Add a message window to ask for a reload if a configuration value has changed.
+- Update the documentation.
+
+### Bugfixes
+
+- Fix bug when tests from other test runners are deleted on startup or refresh having more than one inline test runner. See [Issue #3](https://github.com/Release-Candidate/vscode-ocaml-expect-inline/issues/3).
+
 ## Version 0.3.0 (2023-03-18)
 
 - Add error message window if `dune` does not work in a workspace.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/Release-Candidate.vscode-ocaml-expect-inline)](https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-ocaml-expect-inline)
 [![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/Release-Candidate.vscode-ocaml-expect-inline)](https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-ocaml-expect-inline)
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/Release-Candidate.vscode-ocaml-expect-inline)](https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-ocaml-expect-inline)
+[![Open VSX Version](https://img.shields.io/open-vsx/v/Release-Candidate/vscode-ocaml-expect-inline)](https://open-vsx.org/extension/Release-Candidate/vscode-ocaml-expect-inline)
 
 ![Expect and Inline logo](./images/inline_ppx_banner.png)
 
@@ -47,6 +48,7 @@ This extension lets you run OCaml [PPX Expect](https://github.com/janestreet/ppx
 
 - needs dune
 - test discovery can be slow, because all tests of all test runners have to be run.
+- retries running dune if another instance has locked the project until dune can acquire the lock - may loop forever.
 - when running tests, every test is run on its own, sequentially
 - Uses VS Code's native Test Explorer UI
 
@@ -64,11 +66,26 @@ This extension lets you run OCaml [PPX Expect](https://github.com/janestreet/ppx
 
 Either
 
-- install the extension directly from the Visual Studio Code Marketplace [Expect and inline  Test Explorer](https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-ocaml-expect-inline)
+- install the extension directly from the Visual Studio Code Marketplace [Expect and Inline Tests](https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-ocaml-expect-inline)
+- install the extension directly from the Open VSX Registry [Expect and Inline Tests
+Preview
+](https://open-vsx.org/extension/Release-Candidate/vscode-ocaml-expect-inline)
 - or download the extension from the [latest release at GitHub](https://github.com/Release-Candidate/vscode-ocaml-expect-inline/releases/latest)
 - or build the extension yourself by cloning the [GitHub Repository](https://github.com/Release-Candidate/vscode-ocaml-expect-inline) and running `yarn install` and `yarn package` in the root directory of the cloned repo.
 
 ### Q & A
+
+[What do the groups in the Test Explorer view mean?](#q-what-do-the-groups-in-the-test-explorer-view-mean)
+
+[How can I (re-) discover all tests?](#q-how-can-i-re--discover-all-tests)
+
+[Where can I see the output of the test run(s)?](#q-where-can-i-see-the-output-of-the-test-runs)
+
+[How can I change which test extension's tests are run by the `Run Tests` button in the upper right of the Test Explorer?](#q-how-can-i-change-which-test-extensions-tests-are-run-by-the-run-tests-button-in-the-upper-right-of-the-test-explorer)
+
+[What does the red circle with a dot in the middle mean?](#q-what-does-the-red-circle-with-a-dot-in-the-middle-mean)
+
+[Where can I see the log of the extension?](#q-where-can-i-see-the-log-of-the-extension)
 
 #### Q: What do the groups in the Test Explorer view mean?
 
@@ -111,6 +128,9 @@ A: In the `OUTPUT` tab of the Panel, you have to select the extension named `Exp
 ## Configuration
 
 - `expectppx.discoverOnStartup` - Boolean. Set this to `false` if you do not want to run all expect and inline tests on startup to discover tests. If you want to rediscover all test by running all inline test runners, use the `Refresh Tests` button in the upper right corner of the Test Explorer.
+- `expectppx.discoverInSources` - Boolean. Whether to parse source files on open and save for tests and update the Test Explorer tree. Should be set to `true` if `expectppx.discoverOnStartup` is `false`.
+- `expectppx.dunePath` - Set an absolute path or a path relative to the project root of the Dune executable. Default: `dune` - use the one in the local Opam environment or in `PATH`.
+- `expectppx.excludeRunners` - A list of inline test runner names to be excluded from test discovery an startup or refresh, e.g. because they take too long to finish. E.g. `["inline_test_runner_fsevents_tests.exe"]` to exclude the test runner of the `fsevents_tests` library.
 
 ## Changes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-ocaml-expect-inline",
     "displayName": "OCaml Expect and Inline Tests",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "preview": false,
     "publisher": "release-candidate",
     "description": "Support for OCaml Expect PPX and inline PPX tests.",
@@ -60,7 +60,25 @@
                 "expectppx.discoverOnStartup": {
                     "type": "boolean",
                     "default": true,
-                    "markdownDescription": "Run test discovery on extension startup? If this is false, only tests in open files are added to the Test Explorer tree."
+                    "markdownDescription": "Run test discovery on extension startup? If this is false, only tests in open files are added to the Test Explorer tree. If this is set to `false` set `#expectppx.discoverInSources#` to `true`!"
+                },
+                "expectppx.discoverInSources": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Whether to parse source files for tests when opening or saving them. Must be set to `true` if `#expectppx.discoverOnStartup#` is `false`"
+                },
+                "expectppx.dunePath": {
+                    "type": "string",
+                    "default": "dune",
+                    "markdownDescription": "Path to the Dune executable `dune`, if `opam env` doesn't yield the right one. Can be either an absolute or a path relative to the project's root. Default: `dune`, use the one in the current Opam environment."
+                },
+                "expectppx.excludeRunners": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "markdownDescription": "Add the paths to all inline test runner that take to long to run on startup."
                 }
             }
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -185,6 +185,37 @@ export const cfgDiscoverOnStartup = "discoverOnStartup";
 export const cfgDefaultDiscoverOnStartup = true;
 
 /**
+ * Do parse source files for tests on save or open.
+ */
+export const cfgDiscoverInSources = "discoverInSources";
+
+/**
+ * The default value of `cfgDiscoverInSources`.
+ */
+export const cfgDefaultDiscoverInSources = false;
+
+/**
+ * The path of the Dune Executable.
+ */
+export const cfgDunePath = "dunePath";
+
+/**
+ * The default value for the Dune path.
+ */
+export const cfgDefaultDunePath = duneCmd;
+
+/**
+ * A list of inline test runners to exclude from adding to the Test Explorer on
+ * startup or refresh.
+ */
+export const cfgExcludeRunners = "excludeRunners";
+
+/**
+ * The default value of 'excludeRunners'.
+ */
+export const cfgDefaultExcludeRunners: string[] = [];
+
+/**
  * Return the configuration value for `discoverOnStartup`.
  *
  * @param config The configuration object to use.
@@ -196,4 +227,46 @@ export function getCfgDiscover(config: vscode.WorkspaceConfiguration) {
         return cfgDefaultDiscoverOnStartup;
     }
     return doDiscover;
+}
+
+/**
+ * Return the configuration value for `discoverOnStartup`.
+ *
+ * @param config The configuration object to use.
+ * @returns The configuration value for `discoverOnStartup`.
+ */
+export function getCfgDiscoverInSources(config: vscode.WorkspaceConfiguration) {
+    const doDiscover = config.get<boolean>(cfgDiscoverInSources);
+    if (doDiscover === undefined) {
+        return cfgDefaultDiscoverInSources;
+    }
+    return doDiscover;
+}
+
+/**
+ * Return the configuration value for `dunePath`.
+ *
+ * @param config The configuration object to use.
+ * @returns The configuration value for `dunePath`.
+ */
+export function getCfgDunePath(config: vscode.WorkspaceConfiguration) {
+    const dunePath = config.get<string>(cfgDunePath);
+    if (dunePath === undefined) {
+        return cfgDefaultDunePath;
+    }
+    return dunePath;
+}
+
+/**
+ * Return the configuration value for `excludeRunners`.
+ *
+ * @param config The configuration object to use.
+ * @returns The configuration value for `excludeRunners`.
+ */
+export function getCfgExcludeRunners(config: vscode.WorkspaceConfiguration) {
+    const excludeRunners = config.get<string[]>(cfgExcludeRunners);
+    if (excludeRunners === undefined) {
+        return cfgDefaultExcludeRunners;
+    }
+    return excludeRunners;
 }

--- a/src/extension_helpers.ts
+++ b/src/extension_helpers.ts
@@ -12,6 +12,7 @@
 
 import * as io from "./osInteraction";
 import * as vscode from "vscode";
+import { getCfgDunePath } from "./constants";
 
 /**
  * Object holding additional data about a `TestItem`.
@@ -198,15 +199,12 @@ export function testItemsToWorkspaces(items: readonly vscode.TestItem[]) {
  * @returns `true`, if the dune command is working in directory `root`, `false`
  * else.
  */
-export async function isDuneWorking(
-    root: vscode.WorkspaceFolder,
-    env: { outChannel: vscode.OutputChannel }
-) {
+export async function isDuneWorking(root: vscode.WorkspaceFolder, env: Env) {
     const {
         stdout: duneStdout,
         stderr: duneStderr,
         error: duneError,
-    } = await io.checkDune(root);
+    } = await io.checkDune(root, getCfgDunePath(env.config));
     if (duneError) {
         env.outChannel.appendLine(duneError);
         return false;

--- a/src/parse_source.ts
+++ b/src/parse_source.ts
@@ -122,11 +122,11 @@ async function addTests(
 ) {
     const { groupItem } = getOrCreateParents(env, data.relPath);
     // eslint-disable-next-line no-await-in-loop
-    const out = await io.runDuneBuild(
-        data.relPath.root,
-        data.parent,
-        data.libName
-    );
+    const out = await io.runDuneBuild(data.relPath.root, {
+        duneCmd: c.getCfgDunePath(env.config),
+        libDir: data.parent,
+        libName: data.libName,
+    });
     env.outChannel.appendLine(
         `Dune build output stdout: ${out.stdout} stderr: ${out.stderr} error: ${
             out.error ? out.error : ""

--- a/src/run_tests.ts
+++ b/src/run_tests.ts
@@ -15,6 +15,7 @@ import * as io from "./osInteraction";
 import * as p from "./parsing";
 import * as t from "./list_tests";
 import * as vscode from "vscode";
+import { getCfgDunePath } from "./constants";
 
 /**
  * Run or cancel running tests.
@@ -70,6 +71,7 @@ async function runSingleTest(env: h.Env, test: vscode.TestItem) {
         test.busy = true;
         const out = await io.runRunnerTestsDune({
             root,
+            duneCmd: getCfgDunePath(env.config),
             runner,
             library,
             tests: [`${test.parent?.label}:${test.id}`],

--- a/test/fixtures/test_errors.ts
+++ b/test/fixtures/test_errors.ts
@@ -50,6 +50,57 @@ Error: The constructor TypeError expects 2 argument(s),
        but is applied here to 1 argument(s)`;
 
 /**
+ * Not a compile error.
+ */
+export const noCompileError = `File "test/expect-tests/findlib_tests.ml", line 137, characters 0-575 (0.001 sec)
+[0;31m------ [0m[0;1m/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml[0m
+[0;32m++++++ [0m[0;1m/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml.corrected[0m
+File "/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml", line 140, characters 0-1:
+[0;100;30m |[0m              ; add_rules = []
+[0;100;30m |[0m              }
+[0;100;30m |[0m          }
+[0;100;30m |[0m    ; subs = []
+[0;100;30m |[0m    } |}]
+[0;100;30m |[0m
+[0;100;30m |[0mlet conf () =
+[0;100;30m |[0m  Findlib.Config.load
+[0;100;30m |[0m    (Path.Outside_build_dir.relative db_path "../toolchain")
+[0;100;30m |[0m    ~toolchain:"tlc" ~context:"<context>"
+[0;100;30m |[0m  |> Memo.run
+[0;100;30m |[0m  |> Test_scheduler.(run (create ()))
+[0;100;30m |[0m
+[0;100;30m |[0mlet%expect_test _ =
+[0;100;30m |[0m  let conf = conf () in
+[0;100;30m |[0m  print_dyn (Findlib.Config.to_dyn conf);
+[0;41;30m-|[0m[0m[0;2m  [%expect[0m[0m
+[0;41;30m-|[0m[0m[0;31m    {|[0m[0m
+[0;41;30m-|[0m[0m[0;31m    { vars =[0m[0m
+[0;41;30m-|[0m[0m[0;31m        map[0m[0m
+[0;41;30m-|[0m[0m[0;31m          { "FOO_BAR" :[0m[0m
+[0;41;30m-|[0m[0m[0;31m              { set_rules =[0m[0m
+[0;41;30m-|[0m[0m[0;31m                  [ { preds_required = set { "env"; "tlc" }[0m[0m
+[0;41;30m-|[0m[0m[0;31m                    ; preds_forbidden = set {}[0m[0m
+[0;41;30m-|[0m[0m[0;31m                    ; value = "my variable"[0m[0m
+[0;41;30m-|[0m[0m[0;31m                    }[0m[0m
+[0;41;30m-|[0m[0m[0;31m                  ][0m[0m
+[0;41;30m-|[0m[0m[0;31m              ; add_rules = [][0m[0m
+[0;41;30m-|[0m[0m[0;31m              }[0m[0m
+[0;41;30m-|[0m[0m[0;31m          }[0m[0m
+[0;41;30m-|[0m[0m[0;31m    ; preds = set { "tlc" }[0m[0m
+[0;41;30m-|[0m[0m[0;31m    } |}[0m[0;2m];[0m[0m
+[0;42;30m+|[0m[0m  [%expect[0;32m.unreachable[0m];[0m
+[0;41;30m-|[0m[0m[0;2m  print_dyn (Env.to_dyn (Findlib.Config.env conf));[0m[0m
+[0;41;30m-|[0m[0m[0;2m  [%expect[0m[0;31m {| map { "FOO_BAR" : "my variable" }[0m[0;2m |}][0m[0m
+[0;42;30m+|[0m[0m  print_dyn (Env.to_dyn (Findlib.Config.env conf));[0m
+[0;42;30m+|[0m[0m  [%expect[0;32m.unreachable][0m[0m
+[0;42;30m+|[0m[0m[0;32m[@@expect.uncaught_exn {|[0m[0m
+[0;42;30m+|[0m[0m[0;32m  ( "Error: ocamlfind toolchain tlc isn't defined in\\[0m[0m
+[0;42;30m+|[0m[0m[0;32m   \\n/Users/roland/Documents/code/dune/../unit-tests/findlib-db/../toolchain.d\\[0m[0m
+[0;42;30m+|[0m[0m[0;32m   \\n(context: <context>)\\[0m[0m
+[0;42;30m+|[0m[0m[0;32m   \\n")[0m |}][0m
+`;
+
+/**
  * A 'normal' failed inline test.
  */
 export const testError = `File "lib/interp_common.ml", line 22, characters 0-29: parse true (0.000 sec)
@@ -193,8 +244,7 @@ export const expectError1Object = [
                 name: "Expect -1.1",
                 startCol: 0,
                 endCol: 76,
-                actual: "-1.1",
-                expected: "-1.12",
+                actual: "-|  [%expect {|-1.12|}]\n+|  [%expect {|-1.1|}]",
             },
         ],
     },
@@ -256,8 +306,7 @@ export const expectError2Object = [
                 name: "lib/interp_common.ml Line 57",
                 startCol: 0,
                 endCol: 95,
-                actual: "-1.1",
-                expected: "-1.5",
+                actual: "-|  [%expect {|-1.5|}]\n+|  [%expect {|-1.1|}]",
             },
         ],
     },
@@ -318,8 +367,76 @@ export const expectError3Object = [
                 name: "Add this",
                 startCol: 0,
                 endCol: 104,
-                actual: "Add this",
-                expected: "",
+                actual: "-|  [%expect {||}]\n+|  [%expect {| Add this |}]",
+            },
+        ],
+    },
+];
+
+/**
+ * Expect error with an empty 'expect' value.
+ */
+export const expectError4 = `File "test/expect-tests/findlib_tests.ml", line 137, characters 0-575 (0.001 sec)
+[0;31m------ [0m[0;1m/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml[0m
+[0;32m++++++ [0m[0;1m/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml.corrected[0m
+File "/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml", line 140, characters 0-1:
+[0;100;30m |[0m              ; add_rules = []
+[0;100;30m |[0m              }
+[0;100;30m |[0m          }
+[0;100;30m |[0m    ; subs = []
+[0;100;30m |[0m    } |}]
+[0;100;30m |[0m
+[0;100;30m |[0mlet conf () =
+[0;100;30m |[0m  Findlib.Config.load
+[0;100;30m |[0m    (Path.Outside_build_dir.relative db_path "../toolchain")
+[0;100;30m |[0m    ~toolchain:"tlc" ~context:"<context>"
+[0;100;30m |[0m  |> Memo.run
+[0;100;30m |[0m  |> Test_scheduler.(run (create ()))
+[0;100;30m |[0m
+[0;100;30m |[0mlet%expect_test _ =
+[0;100;30m |[0m  let conf = conf () in
+[0;100;30m |[0m  print_dyn (Findlib.Config.to_dyn conf);
+[0;41;30m-|[0m[0m[0;2m  [%expect[0m[0m
+[0;41;30m-|[0m[0m[0;31m    {|[0m[0m
+[0;41;30m-|[0m[0m[0;31m    { vars =[0m[0m
+[0;41;30m-|[0m[0m[0;31m        map[0m[0m
+[0;41;30m-|[0m[0m[0;31m          { "FOO_BAR" :[0m[0m
+[0;41;30m-|[0m[0m[0;31m              { set_rules =[0m[0m
+[0;41;30m-|[0m[0m[0;31m                  [ { preds_required = set { "env"; "tlc" }[0m[0m
+[0;41;30m-|[0m[0m[0;31m                    ; preds_forbidden = set {}[0m[0m
+[0;41;30m-|[0m[0m[0;31m                    ; value = "my variable"[0m[0m
+[0;41;30m-|[0m[0m[0;31m                    }[0m[0m
+[0;41;30m-|[0m[0m[0;31m                  ][0m[0m
+[0;41;30m-|[0m[0m[0;31m              ; add_rules = [][0m[0m
+[0;41;30m-|[0m[0m[0;31m              }[0m[0m
+[0;41;30m-|[0m[0m[0;31m          }[0m[0m
+[0;41;30m-|[0m[0m[0;31m    ; preds = set { "tlc" }[0m[0m
+[0;41;30m-|[0m[0m[0;31m    } |}[0m[0;2m];[0m[0m
+[0;42;30m+|[0m[0m  [%expect[0;32m.unreachable[0m];[0m
+[0;41;30m-|[0m[0m[0;2m  print_dyn (Env.to_dyn (Findlib.Config.env conf));[0m[0m
+[0;41;30m-|[0m[0m[0;2m  [%expect[0m[0;31m {| map { "FOO_BAR" : "my variable" }[0m[0;2m |}][0m[0m
+[0;42;30m+|[0m[0m  print_dyn (Env.to_dyn (Findlib.Config.env conf));[0m
+[0;42;30m+|[0m[0m  [%expect[0;32m.unreachable][0m[0m
+[0;42;30m+|[0m[0m[0;32m[@@expect.uncaught_exn {|[0m[0m
+[0;42;30m+|[0m[0m[0;32m  ( "Error: ocamlfind toolchain tlc isn't defined in\\[0m[0m
+[0;42;30m+|[0m[0m[0;32m   \\n/Users/roland/Documents/code/dune/../unit-tests/findlib-db/../toolchain.d\\[0m[0m
+[0;42;30m+|[0m[0m[0;32m   \\n(context: <context>)\\[0m[0m
+[0;42;30m+|[0m[0m[0;32m   \\n")[0m |}][0m
+`;
+
+/**
+ * The result of parsing `expectError4`.
+ */
+export const expectError4Object = [
+    {
+        name: "test/expect-tests/findlib_tests.ml",
+        tests: [
+            {
+                line: 137,
+                name: "test/expect-tests/findlib_tests.ml Line 137",
+                startCol: 0,
+                endCol: 575,
+                actual: '-|  [%expect\n-|    {|\n-|    { vars =\n-|        map\n-|          { "FOO_BAR" :\n-|              { set_rules =\n-|                  [ { preds_required = set { "env"; "tlc" }\n-|                    ; preds_forbidden = set {}\n-|                    ; value = "my variable"\n-|                    }\n-|                  ]\n-|              ; add_rules = []\n-|              }\n-|          }\n-|    ; preds = set { "tlc" }\n-|    } |}];\n+|  [%expect.unreachable];\n-|  print_dyn (Env.to_dyn (Findlib.Config.env conf));\n-|  [%expect {| map { "FOO_BAR" : "my variable" } |}]\n+|  print_dyn (Env.to_dyn (Findlib.Config.env conf));\n+|  [%expect.unreachable]\n+|[@@expect.uncaught_exn {|\n+|  ( "Error: ocamlfind toolchain tlc isn\'t defined in\\\n+|   \\n/Users/roland/Documents/code/dune/../unit-tests/findlib-db/../toolchain.d\\\n+|   \\n(context: <context>)\\\n+|   \\n") |}]',
             },
         ],
     },

--- a/test/parsing-test.ts
+++ b/test/parsing-test.ts
@@ -123,6 +123,13 @@ mocha.describe("Parsing Functions", () => {
                 "v3.6.2 should be valid"
             );
         });
+        mocha.it("3.7.0-181-g4245029 is valid", () => {
+            chai.assert.strictEqual(
+                parse.isValidVersion("3.7.0-181-g4245029"),
+                true,
+                "3.7.0-181-g4245029 should be valid"
+            );
+        });
         mocha.it("Version 3.6.2~9-156_78 is valid", () => {
             chai.assert.strictEqual(
                 parse.isValidVersion("Version 3.6.2~9-156_78"),
@@ -396,6 +403,13 @@ mocha.describe("Parsing Functions", () => {
                 "compilerError3 -> true"
             );
         });
+        mocha.it("Not a compile error -> false", () => {
+            chai.assert.deepEqual(
+                parse.isCompileError(testErrors.noCompileError),
+                false,
+                "noCompileError -> false"
+            );
+        });
         mocha.it("List of tests -> false", () => {
             chai.assert.deepEqual(
                 parse.isCompileError(testLists.normalList),
@@ -472,6 +486,13 @@ mocha.describe("Parsing Functions", () => {
                 parse.parseTestErrors(testErrors.expectError3),
                 testErrors.expectError3Object,
                 "expectError3 -> expectError3Object"
+            );
+        });
+        mocha.it("Failed expect test 4 -> one test", () => {
+            chai.assert.deepEqual(
+                parse.parseTestErrors(testErrors.expectError4),
+                testErrors.expectError4Object,
+                "expectError4 -> expectError4Object"
             );
         });
         mocha.it("Failed test 1 -> one test", () => {

--- a/vscode-ocaml-expect-inline.code-workspace
+++ b/vscode-ocaml-expect-inline.code-workspace
@@ -4,7 +4,7 @@
             "path": "."
         },
         {
-            "path": "../OCaml-Interp"
+            "path": "../dune"
         }
     ],
     "settings": {
@@ -19,6 +19,7 @@
             "Subtr",
             "Unop",
             "VSIX"
-        ]
+        ],
+        "expectppx.dunePath": "_opam/bin/dune"
     }
 }


### PR DESCRIPTION
- New configuration values:
  - `expectppx.discoverInSources` - Whether to parse source files on open and save for tests and update the Test Explorer tree. Should be set to `true` if `expectppx.discoverOnStartup` is `false`.
  - `expectppx.dunePath` - Set an absolute path or a path relative to the project root of the Dune executable. Default: `dune` - use the one in the local Opam environment or in `PATH`. See #3 
  - `expectppx.excludeRunners` - A list of inline test runner names to be excluded from test discovery an startup or refresh, e.g. because they take too long to finish.
- Add a message window to ask for a reload if a configuration value has changed.
- Update the documentation.

### Bugfix

- Fix bug when tests from other test runners are deleted on startup or refresh having more than one inline test runner. See #3 