### PR TITLE
Run test runners with 'list tests' argument to discover

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -70,6 +70,12 @@
 			"task": "compile",
 			"problemMatcher": [],
 			"label": "yarn: compile"
+		},
+		{
+			"type": "yarn",
+			"task": "publish-ovsx",
+			"problemMatcher": [],
+			"label": "yarn: publish-ovsx"
 		}
 	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # OCaml Expect and Inline Test Explorer for Visual Studio Code Changelog
 
+## Version 0.5.0 (2023-03-21)
+
+- No need to run all tests at startup or refresh. Use the `-list-test-names` argument of the inline test runners.
+- Disable ANSI color escape sequences in output of test failures.
+- Update the documentation.
+
+### Internal Changes
+
+- Remove ANSI escape sequences from test fixtures.
+- Add yarn target for the Open VSX Registry.
+
 ## Version 0.4.0 (2023-03-20)
 
 - New configuration values:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ On starting the extension - see `activationEvents` in [./package.json](./package
 
   - search for the inline test runner executables
   - run every one of them with `dune exec` so that the test runners are recompiled if necessary.
-  - use test runner arguments to run and list all tests
+  - use test runner arguments to list all tests
   - parse this output and add, update or remove nodes in the Test Explorer's tree and set the  location of the tests in the source files
 
 If a user presses the `Refresh Tests` button - see `controller.refreshHandler`:
@@ -29,7 +29,7 @@ If a user runs a test - see function `runHandler` in [./src/run_tests.ts](./src/
   - parse the output of the test
   - if a test failed, set the 'test message' to the output of the failed test
 
-If a source file has been opened or saved - see function `parseTextDocument` in file [./src/parse_source.ts](./src/parse_source.ts):
+If a source file has been opened or saved and the configuration is set - see function `parseTextDocument` in file [./src/parse_source.ts](./src/parse_source.ts):
 
 - parse the source file for a list of tests
 - check the parent directories of the source file for a dune configuration file `dune`

--- a/README.md
+++ b/README.md
@@ -37,17 +37,13 @@ This extension lets you run OCaml [PPX Expect](https://github.com/janestreet/ppx
 - uses dune to compile and run the tests
 - support for expect PPX tests and inline PPX tests
 - filtering of tests by name
-- parses the test list output of the test runners to fill the Test Explorer view: the test tree view is consistent with the test runners
-- parses OCaml source files on open and save for new, updated or deleted tests
-- configurable test discovery on startup: if `Expectppx: Discover On Startup` is set to `false` no tests are run on startup, tests are only run by explicitly running tests or pressing the `Refresh Tests` button.
-- support for multiple workspaces
+- parses the test list output of the test runners to fill the Test Explorer view: faster than grepping every source file for test cases and the test tree view is consistent with the test runners
 - retries running dune if another instance has locked the project until dune can acquire the lock
 - Uses VS Code's native Test Explorer (no additional extension needed)
 
 ### Drawbacks
 
 - needs dune
-- test discovery can be slow, because all tests of all test runners have to be run.
 - retries running dune if another instance has locked the project until dune can acquire the lock - may loop forever.
 - when running tests, every test is run on its own, sequentially
 - Uses VS Code's native Test Explorer UI
@@ -67,9 +63,7 @@ This extension lets you run OCaml [PPX Expect](https://github.com/janestreet/ppx
 Either
 
 - install the extension directly from the Visual Studio Code Marketplace [Expect and Inline Tests](https://marketplace.visualstudio.com/items?itemName=release-candidate.vscode-ocaml-expect-inline)
-- install the extension directly from the Open VSX Registry [Expect and Inline Tests
-Preview
-](https://open-vsx.org/extension/Release-Candidate/vscode-ocaml-expect-inline)
+- install the extension directly from the Open VSX Registry [Expect and Inline Tests](https://open-vsx.org/extension/Release-Candidate/vscode-ocaml-expect-inline)
 - or download the extension from the [latest release at GitHub](https://github.com/Release-Candidate/vscode-ocaml-expect-inline/releases/latest)
 - or build the extension yourself by cloning the [GitHub Repository](https://github.com/Release-Candidate/vscode-ocaml-expect-inline) and running `yarn install` and `yarn package` in the root directory of the cloned repo.
 
@@ -127,10 +121,10 @@ A: In the `OUTPUT` tab of the Panel, you have to select the extension named `Exp
 
 ## Configuration
 
-- `expectppx.discoverOnStartup` - Boolean. Set this to `false` if you do not want to run all expect and inline tests on startup to discover tests. If you want to rediscover all test by running all inline test runners, use the `Refresh Tests` button in the upper right corner of the Test Explorer.
-- `expectppx.discoverInSources` - Boolean. Whether to parse source files on open and save for tests and update the Test Explorer tree. Should be set to `true` if `expectppx.discoverOnStartup` is `false`.
 - `expectppx.dunePath` - Set an absolute path or a path relative to the project root of the Dune executable. Default: `dune` - use the one in the local Opam environment or in `PATH`.
 - `expectppx.excludeRunners` - A list of inline test runner names to be excluded from test discovery an startup or refresh, e.g. because they take too long to finish. E.g. `["inline_test_runner_fsevents_tests.exe"]` to exclude the test runner of the `fsevents_tests` library.
+- `expectppx.discoverOnStartup` - Boolean. Set this to `false` if you do not want to run or compile all expect and inline test runners on startup to discover tests. If you want to rediscover all test by running all inline test runners, use the `Refresh Tests` button in the upper right corner of the Test Explorer.
+- `expectppx.discoverInSources` - Boolean. Whether to parse source files on open and save for tests and update the Test Explorer tree. Should be set to `true` if `expectppx.discoverOnStartup` is `false`.
 
 ## Changes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-ocaml-expect-inline",
     "displayName": "OCaml Expect and Inline Tests",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "preview": false,
     "publisher": "release-candidate",
     "description": "Support for OCaml Expect PPX and inline PPX tests.",
@@ -102,6 +102,7 @@
         "eslint-plugin-mocha": "^10.1.0",
         "glob": "^9.1.0",
         "mocha": "^10.2.0",
+        "ovsx": "^0.8.0",
         "source-map-support": "^0.5.21",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.1.2",
@@ -123,6 +124,7 @@
         "bundle": "yarn --ignore-engines run esbuild-base --minify",
         "vscode:prepublish": "yarn --ignore-engines run bundle",
         "package": "vsce package",
-        "publish-vsix": "vsce publish --yarn"
+        "publish-vsix": "vsce publish --yarn",
+        "publish-ovsx": "ovsx publish vscode-ocaml-expect-inline-*.vsix --pat"
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -132,9 +132,20 @@ export const runnerLibArg = "inline-test-runner";
 export const runnerTestArg = "-only-test";
 
 /**
- * Options to pass to the inline test runner to get a list of all tests.
+ * Option to pass to the inline test runner to get a list of all tests.
  */
-export const runnerListOption = "-verbose";
+export const runnerListOption = "-list-test-names";
+
+/**
+ * Option to pass to the inline test runner to get a list of all test which are
+ * being run, not just the failed ones.
+ */
+export const runnerVerboseOption = "-verbose";
+
+/**
+ * Option to pass to the inline test runner to get colorless output.
+ */
+export const runnerNoColorOption = "-no-color";
 
 /**
  * Glob pattern to find the inline runner executable.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -149,7 +149,7 @@ function configChanged(env: h.Env, e: vscode.ConfigurationChangeEvent) {
         vscode.window
             .showInformationMessage(
                 "The configuration has changed!\nReload the window for the changes to take effect.",
-                "Reload"
+                "Reload Now"
             )
             // eslint-disable-next-line no-unused-vars
             .then((_) =>

--- a/src/list_tests.ts
+++ b/src/list_tests.ts
@@ -53,7 +53,7 @@ export async function addTests(
  */
 // eslint-disable-next-line max-statements
 async function addWorkspaceTests(env: h.Env, root: vscode.WorkspaceFolder) {
-    await setOpamEnv(root, env);
+    await setOpamEnv(env, root);
 
     // eslint-disable-next-line @typescript-eslint/no-extra-parens
     if (!(await h.isDuneWorking(root, env))) {
@@ -97,9 +97,10 @@ async function addWorkspaceTests(env: h.Env, root: vscode.WorkspaceFolder) {
 
 /**
  * Run `opam env`, parse its output and set the environment accordingly.
+ * @param env The extension's environment.
  * @param root The working directory for `opam`.
  */
-async function setOpamEnv(root: vscode.WorkspaceFolder, env: h.Env) {
+async function setOpamEnv(env: h.Env, root: vscode.WorkspaceFolder) {
     const opamEnv = await io.opamEnv(root);
     for (const oEnv of opamEnv) {
         process.env[oEnv.name] = oEnv.value;

--- a/src/osInteraction.ts
+++ b/src/osInteraction.ts
@@ -264,11 +264,7 @@ async function runDuneCommand(
         if (parse.isDuneLocked(out.stderr)) {
             // eslint-disable-next-line no-magic-numbers
             await sleep(sleepTime * 1000);
-            return runDuneCommand(
-                root,
-                { args: cmd.args, duneCmd: cmd.duneCmd },
-                sleepTime
-            );
+            return runDuneCommand(root, cmd, sleepTime);
         }
     } else {
         return out;
@@ -345,6 +341,7 @@ export async function runRunnerListDune(
                 c.runnerLibArg,
                 parse.getLibrary(runner),
                 c.runnerListOption,
+                c.runnerNoColorOption,
             ],
         },
         // eslint-disable-next-line no-magic-numbers
@@ -377,7 +374,8 @@ export async function runRunnerTestsDune(data: {
                 c.duneEndArgs,
                 c.runnerLibArg,
                 data.library,
-                c.runnerListOption,
+                c.runnerVerboseOption,
+                c.runnerNoColorOption,
                 c.runnerTestArg,
                 ...data.tests,
             ],

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -208,7 +208,7 @@ export function isDuneLocked(s: string) {
  * @param s The string to sanitize.
  * @returns The string `s` with removed ANSI color sequences.
  */
-export function removeColorCodes(s: string) {
+export function removeColorCodes1(s: string) {
     return s.replace(ansiRegexp, "");
 }
 
@@ -342,20 +342,19 @@ export function parseTestList(s: string) {
  * `{ name: group, tests: [{ id, name, line, startCol, endCol, expected, actual }] }`.
  */
 export function parseTestErrors(s: string) {
-    const sanitized = removeColorCodes(s);
     const errors = parseTestHelper<TestTypeIn>(
         testErrorRegex,
-        sanitized,
+        s,
         errorMatchToObject
     );
     const exceptionErrors = parseTestHelper<TestTypeIn>(
         testExceptionRegex,
-        sanitized,
+        s,
         exceptionMatchToObject
     );
     const expectErrors = parseTestHelper<TestTypeIn>(
         testExpectRegex,
-        sanitized,
+        s,
         expectMatchToObject
     );
     return groupTestHelper(errors.concat(exceptionErrors).concat(expectErrors));

--- a/src/run_tests.ts
+++ b/src/run_tests.ts
@@ -166,7 +166,7 @@ async function setTestError(
         data.out.stderr ? data.out.stderr : ""
     );
     let message = await constructMessage({
-        txt: output ? p.removeColorCodes(output) : "",
+        txt: output ? output : "",
         test: data.test,
         testData: env.testData,
         errElem,

--- a/test/fixtures/test_errors.ts
+++ b/test/fixtures/test_errors.ts
@@ -53,51 +53,51 @@ Error: The constructor TypeError expects 2 argument(s),
  * Not a compile error.
  */
 export const noCompileError = `File "test/expect-tests/findlib_tests.ml", line 137, characters 0-575 (0.001 sec)
-[0;31m------ [0m[0;1m/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml[0m
-[0;32m++++++ [0m[0;1m/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml.corrected[0m
+------ /Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml
+++++++ /Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml.corrected
 File "/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml", line 140, characters 0-1:
-[0;100;30m |[0m              ; add_rules = []
-[0;100;30m |[0m              }
-[0;100;30m |[0m          }
-[0;100;30m |[0m    ; subs = []
-[0;100;30m |[0m    } |}]
-[0;100;30m |[0m
-[0;100;30m |[0mlet conf () =
-[0;100;30m |[0m  Findlib.Config.load
-[0;100;30m |[0m    (Path.Outside_build_dir.relative db_path "../toolchain")
-[0;100;30m |[0m    ~toolchain:"tlc" ~context:"<context>"
-[0;100;30m |[0m  |> Memo.run
-[0;100;30m |[0m  |> Test_scheduler.(run (create ()))
-[0;100;30m |[0m
-[0;100;30m |[0mlet%expect_test _ =
-[0;100;30m |[0m  let conf = conf () in
-[0;100;30m |[0m  print_dyn (Findlib.Config.to_dyn conf);
-[0;41;30m-|[0m[0m[0;2m  [%expect[0m[0m
-[0;41;30m-|[0m[0m[0;31m    {|[0m[0m
-[0;41;30m-|[0m[0m[0;31m    { vars =[0m[0m
-[0;41;30m-|[0m[0m[0;31m        map[0m[0m
-[0;41;30m-|[0m[0m[0;31m          { "FOO_BAR" :[0m[0m
-[0;41;30m-|[0m[0m[0;31m              { set_rules =[0m[0m
-[0;41;30m-|[0m[0m[0;31m                  [ { preds_required = set { "env"; "tlc" }[0m[0m
-[0;41;30m-|[0m[0m[0;31m                    ; preds_forbidden = set {}[0m[0m
-[0;41;30m-|[0m[0m[0;31m                    ; value = "my variable"[0m[0m
-[0;41;30m-|[0m[0m[0;31m                    }[0m[0m
-[0;41;30m-|[0m[0m[0;31m                  ][0m[0m
-[0;41;30m-|[0m[0m[0;31m              ; add_rules = [][0m[0m
-[0;41;30m-|[0m[0m[0;31m              }[0m[0m
-[0;41;30m-|[0m[0m[0;31m          }[0m[0m
-[0;41;30m-|[0m[0m[0;31m    ; preds = set { "tlc" }[0m[0m
-[0;41;30m-|[0m[0m[0;31m    } |}[0m[0;2m];[0m[0m
-[0;42;30m+|[0m[0m  [%expect[0;32m.unreachable[0m];[0m
-[0;41;30m-|[0m[0m[0;2m  print_dyn (Env.to_dyn (Findlib.Config.env conf));[0m[0m
-[0;41;30m-|[0m[0m[0;2m  [%expect[0m[0;31m {| map { "FOO_BAR" : "my variable" }[0m[0;2m |}][0m[0m
-[0;42;30m+|[0m[0m  print_dyn (Env.to_dyn (Findlib.Config.env conf));[0m
-[0;42;30m+|[0m[0m  [%expect[0;32m.unreachable][0m[0m
-[0;42;30m+|[0m[0m[0;32m[@@expect.uncaught_exn {|[0m[0m
-[0;42;30m+|[0m[0m[0;32m  ( "Error: ocamlfind toolchain tlc isn't defined in\\[0m[0m
-[0;42;30m+|[0m[0m[0;32m   \\n/Users/roland/Documents/code/dune/../unit-tests/findlib-db/../toolchain.d\\[0m[0m
-[0;42;30m+|[0m[0m[0;32m   \\n(context: <context>)\\[0m[0m
-[0;42;30m+|[0m[0m[0;32m   \\n")[0m |}][0m
+ |              ; add_rules = []
+ |              }
+ |          }
+ |    ; subs = []
+ |    } |}]
+ |
+ |let conf () =
+ |  Findlib.Config.load
+ |    (Path.Outside_build_dir.relative db_path "../toolchain")
+ |    ~toolchain:"tlc" ~context:"<context>"
+ |  |> Memo.run
+ |  |> Test_scheduler.(run (create ()))
+ |
+ |let%expect_test _ =
+ |  let conf = conf () in
+ |  print_dyn (Findlib.Config.to_dyn conf);
+-|  [%expect
+-|    {|
+-|    { vars =
+-|        map
+-|          { "FOO_BAR" :
+-|              { set_rules =
+-|                  [ { preds_required = set { "env"; "tlc" }
+-|                    ; preds_forbidden = set {}
+-|                    ; value = "my variable"
+-|                    }
+-|                  ]
+-|              ; add_rules = []
+-|              }
+-|          }
+-|    ; preds = set { "tlc" }
+-|    } |}];
++|  [%expect.unreachable];
+-|  print_dyn (Env.to_dyn (Findlib.Config.env conf));
+-|  [%expect {| map { "FOO_BAR" : "my variable" } |}]
++|  print_dyn (Env.to_dyn (Findlib.Config.env conf));
++|  [%expect.unreachable]
++|[@@expect.uncaught_exn {|
++|  ( "Error: ocamlfind toolchain tlc isn't defined in\\
++|   \\n/Users/roland/Documents/code/dune/../unit-tests/findlib-db/../toolchain.d\\
++|   \\n(context: <context>)\\
++|   \\n") |}]
 `;
 
 /**
@@ -194,43 +194,43 @@ export const exceptionError2Object = [
  * /Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml, line 34, start: 0, end: 1
  */
 export const expectError1 = `File "lib/interp_common.ml", line 32, characters 0-76: Expect -1.1 (0.000 sec)
-[0;31m------ [0m[0;1m/Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml[0m
-[0;32m++++++ [0m[0;1m/Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml.corrected[0m
+------ /Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml
+++++++ /Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml.corrected
 File "/Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml", line 34, characters 0-1:
-[0;100;30m |[0m
-[0;100;30m |[0m(*******************************************************************************
-[0;100;30m |[0m    Some tests. *)
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse true" = true (*Bool true = parse "true"*)
-[0;100;30m |[0mlet%test_unit _ = ignore (parse "false")
-[0;100;30m |[0mlet%test "parse false" = Bool false = parse "false"
-[0;100;30m |[0mlet%test "parse not true1" = Unop (Not, Bool true) = parse "not true"
-[0;100;30m |[0mlet%test "parse not false" = Unop (Not, Bool false) = parse "not false"
-[0;100;30m |[0mlet%test "parse 1" = Int 1 = parse "1"
-[0;100;30m |[0mlet%test "parse 1.1" = Float 1.1 = parse "1.1"
-[0;100;30m |[0mlet%test "parse -1" = Unop (Minus, Int 1) = parse "-1"
-[0;100;30m |[0mlet%test "parse -1.1" = Unop (Minus, Float 1.1) = parse "-1.1"
-[0;100;30m |[0m
-[0;100;30m |[0mlet%expect_test "Expect -1.1" =
-[0;100;30m |[0m  print_string "-1.1";
-[0;41;30m-|[0m[0m[0;2m  [%expect {|-1.[0m[0;31m12[0m[0;2m|}][0m[0m
-[0;42;30m+|[0m[0m  [%expect {|-1.[0;32m1[0m|}][0m
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse 11+11" = Binop (Add, Int 11, Int 11) = parse "11+11"
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse not true" =
-[0;100;30m |[0m  Binop (Add, Float 21., Float 21.2) = parse "21.+21.2"
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse 11-11" = Binop (Subtr, Int 11, Int 11) = parse "11-11"
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse 21.-21.2" =
-[0;100;30m |[0m  Binop (Subtr, Float 21., Float 21.2) = parse "21.-21.2"
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse 11*11" = Binop (Mult, Int 11, Int 11) = parse "11*11"
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse 21.*21.2" =
-[0;100;30m |[0m  Binop (Mult, Float 21., Float 21.2) = parse "21.*21.2"
-[0;100;30m |[0m`;
+ |
+ |(*******************************************************************************
+ |    Some tests. *)
+ |
+ |let%test "parse true" = true (*Bool true = parse "true"*)
+ |let%test_unit _ = ignore (parse "false")
+ |let%test "parse false" = Bool false = parse "false"
+ |let%test "parse not true1" = Unop (Not, Bool true) = parse "not true"
+ |let%test "parse not false" = Unop (Not, Bool false) = parse "not false"
+ |let%test "parse 1" = Int 1 = parse "1"
+ |let%test "parse 1.1" = Float 1.1 = parse "1.1"
+ |let%test "parse -1" = Unop (Minus, Int 1) = parse "-1"
+ |let%test "parse -1.1" = Unop (Minus, Float 1.1) = parse "-1.1"
+ |
+ |let%expect_test "Expect -1.1" =
+ |  print_string "-1.1";
+-|  [%expect {|-1.12|}]
++|  [%expect {|-1.1|}]
+ |
+ |let%test "parse 11+11" = Binop (Add, Int 11, Int 11) = parse "11+11"
+ |
+ |let%test "parse not true" =
+ |  Binop (Add, Float 21., Float 21.2) = parse "21.+21.2"
+ |
+ |let%test "parse 11-11" = Binop (Subtr, Int 11, Int 11) = parse "11-11"
+ |
+ |let%test "parse 21.-21.2" =
+ |  Binop (Subtr, Float 21., Float 21.2) = parse "21.-21.2"
+ |
+ |let%test "parse 11*11" = Binop (Mult, Int 11, Int 11) = parse "11*11"
+ |
+ |let%test "parse 21.*21.2" =
+ |  Binop (Mult, Float 21., Float 21.2) = parse "21.*21.2"
+ |`;
 
 /**
  * The result of parsing `expectError1`.
@@ -255,43 +255,43 @@ export const expectError1Object = [
  * /Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml, line 34, start: 0, end: 1
  */
 export const expectError2 = `File "lib/interp_common.ml", line 57, characters 0-95 (0.000 sec)
-[0;31m------ [0m[0;1m/Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml[0m
-[0;32m++++++ [0m[0;1m/Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml.corrected[0m
+------ /Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml
+++++++ /Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml.corrected
 File "/Users/roland/Documents/code/OCaml-Interp/lib/interp_common.ml", line 59, characters 0-1:
-[0;100;30m |[0mlet%test "parse 11-11" = true (*Binop (Subtr, Int 11, Int 11) = parse "11-11"*)
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test_unit "parse 21.-21.2" =
-[0;100;30m |[0m  (*Binop (Subtr, Float 21., Float 21.2) = parse "21.-21.2"*)
-[0;100;30m |[0m   [%test_result: int] 5 ~expect:4
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse 11*11" = true (*Binop (Mult, Int 11, Int 11) = parse "11*11"*)
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse 21.*21.2" = true
-[0;100;30m |[0m (* Binop (Mult, Float 21., Float 21.2) = parse "21.*21.2"*)
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse 11/-11" = true
-[0;100;30m |[0m (* Binop (Div, Int 11, Unop (Minus, Int 11)) = parse "11/-11"*)
-[0;100;30m |[0m
-[0;100;30m |[0mlet%expect_test _ =
-[0;100;30m |[0m  Stdio.Out_channel.output_string Stdio.stdout "-1.1";
-[0;41;30m-|[0m[0m[0;2m  [%expect {|-1.[0m[0;31m5[0m[0;2m|}][0m[0m
-[0;42;30m+|[0m[0m  [%expect {|-1.[0;32m1[0m|}][0m
-[0;100;30m |[0m
-[0;100;30m |[0mlet%test "parse 21./-21.2" = failwith "NO"
-[0;100;30m |[0m  (*Binop (Div, Float 21., Unop (Minus, Float 21.2)) = parse "21./-21.2"*)
-[0;100;30m |[0m
-[0;100;30m |[0m(* =============================================================================
-[0;100;30m |[0m   Error messages
-[0;100;30m |[0m*)
-[0;100;30m |[0m
-[0;100;30m |[0mexception TypeError of string
-[0;100;30m |[0mexception RuntimeError of string
-[0;100;30m |[0m
-[0;100;30m |[0mlet type_error s = raise (TypeError s)
-[0;100;30m |[0mlet runtime_error s = raise (RuntimeError s)
-[0;100;30m |[0m
-[0;100;30m |[0m(** [unbound_var_err x] returns the error message for an unbound variable x. *)
-[0;100;30m |[0mlet unbound_var_err x = "Unbound variable " ^ x
+ |let%test "parse 11-11" = true (*Binop (Subtr, Int 11, Int 11) = parse "11-11"*)
+ |
+ |let%test_unit "parse 21.-21.2" =
+ |  (*Binop (Subtr, Float 21., Float 21.2) = parse "21.-21.2"*)
+ |   [%test_result: int] 5 ~expect:4
+ |
+ |let%test "parse 11*11" = true (*Binop (Mult, Int 11, Int 11) = parse "11*11"*)
+ |
+ |let%test "parse 21.*21.2" = true
+ | (* Binop (Mult, Float 21., Float 21.2) = parse "21.*21.2"*)
+ |
+ |let%test "parse 11/-11" = true
+ | (* Binop (Div, Int 11, Unop (Minus, Int 11)) = parse "11/-11"*)
+ |
+ |let%expect_test _ =
+ |  Stdio.Out_channel.output_string Stdio.stdout "-1.1";
+-|  [%expect {|-1.5|}]
++|  [%expect {|-1.1|}]
+ |
+ |let%test "parse 21./-21.2" = failwith "NO"
+ |  (*Binop (Div, Float 21., Unop (Minus, Float 21.2)) = parse "21./-21.2"*)
+ |
+ |(* =============================================================================
+ |   Error messages
+ |*)
+ |
+ |exception TypeError of string
+ |exception RuntimeError of string
+ |
+ |let type_error s = raise (TypeError s)
+ |let runtime_error s = raise (RuntimeError s)
+ |
+ |(** [unbound_var_err x] returns the error message for an unbound variable x. *)
+ |let unbound_var_err x = "Unbound variable " ^ x
 `;
 
 /**
@@ -377,51 +377,51 @@ export const expectError3Object = [
  * Expect error with an empty 'expect' value.
  */
 export const expectError4 = `File "test/expect-tests/findlib_tests.ml", line 137, characters 0-575 (0.001 sec)
-[0;31m------ [0m[0;1m/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml[0m
-[0;32m++++++ [0m[0;1m/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml.corrected[0m
+------ /Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml
+++++++ /Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml.corrected
 File "/Users/roland/Documents/code/dune/test/expect-tests/findlib_tests.ml", line 140, characters 0-1:
-[0;100;30m |[0m              ; add_rules = []
-[0;100;30m |[0m              }
-[0;100;30m |[0m          }
-[0;100;30m |[0m    ; subs = []
-[0;100;30m |[0m    } |}]
-[0;100;30m |[0m
-[0;100;30m |[0mlet conf () =
-[0;100;30m |[0m  Findlib.Config.load
-[0;100;30m |[0m    (Path.Outside_build_dir.relative db_path "../toolchain")
-[0;100;30m |[0m    ~toolchain:"tlc" ~context:"<context>"
-[0;100;30m |[0m  |> Memo.run
-[0;100;30m |[0m  |> Test_scheduler.(run (create ()))
-[0;100;30m |[0m
-[0;100;30m |[0mlet%expect_test _ =
-[0;100;30m |[0m  let conf = conf () in
-[0;100;30m |[0m  print_dyn (Findlib.Config.to_dyn conf);
-[0;41;30m-|[0m[0m[0;2m  [%expect[0m[0m
-[0;41;30m-|[0m[0m[0;31m    {|[0m[0m
-[0;41;30m-|[0m[0m[0;31m    { vars =[0m[0m
-[0;41;30m-|[0m[0m[0;31m        map[0m[0m
-[0;41;30m-|[0m[0m[0;31m          { "FOO_BAR" :[0m[0m
-[0;41;30m-|[0m[0m[0;31m              { set_rules =[0m[0m
-[0;41;30m-|[0m[0m[0;31m                  [ { preds_required = set { "env"; "tlc" }[0m[0m
-[0;41;30m-|[0m[0m[0;31m                    ; preds_forbidden = set {}[0m[0m
-[0;41;30m-|[0m[0m[0;31m                    ; value = "my variable"[0m[0m
-[0;41;30m-|[0m[0m[0;31m                    }[0m[0m
-[0;41;30m-|[0m[0m[0;31m                  ][0m[0m
-[0;41;30m-|[0m[0m[0;31m              ; add_rules = [][0m[0m
-[0;41;30m-|[0m[0m[0;31m              }[0m[0m
-[0;41;30m-|[0m[0m[0;31m          }[0m[0m
-[0;41;30m-|[0m[0m[0;31m    ; preds = set { "tlc" }[0m[0m
-[0;41;30m-|[0m[0m[0;31m    } |}[0m[0;2m];[0m[0m
-[0;42;30m+|[0m[0m  [%expect[0;32m.unreachable[0m];[0m
-[0;41;30m-|[0m[0m[0;2m  print_dyn (Env.to_dyn (Findlib.Config.env conf));[0m[0m
-[0;41;30m-|[0m[0m[0;2m  [%expect[0m[0;31m {| map { "FOO_BAR" : "my variable" }[0m[0;2m |}][0m[0m
-[0;42;30m+|[0m[0m  print_dyn (Env.to_dyn (Findlib.Config.env conf));[0m
-[0;42;30m+|[0m[0m  [%expect[0;32m.unreachable][0m[0m
-[0;42;30m+|[0m[0m[0;32m[@@expect.uncaught_exn {|[0m[0m
-[0;42;30m+|[0m[0m[0;32m  ( "Error: ocamlfind toolchain tlc isn't defined in\\[0m[0m
-[0;42;30m+|[0m[0m[0;32m   \\n/Users/roland/Documents/code/dune/../unit-tests/findlib-db/../toolchain.d\\[0m[0m
-[0;42;30m+|[0m[0m[0;32m   \\n(context: <context>)\\[0m[0m
-[0;42;30m+|[0m[0m[0;32m   \\n")[0m |}][0m
+ |              ; add_rules = []
+ |              }
+ |          }
+ |    ; subs = []
+ |    } |}]
+ |
+ |let conf () =
+ |  Findlib.Config.load
+ |    (Path.Outside_build_dir.relative db_path "../toolchain")
+ |    ~toolchain:"tlc" ~context:"<context>"
+ |  |> Memo.run
+ |  |> Test_scheduler.(run (create ()))
+ |
+ |let%expect_test _ =
+ |  let conf = conf () in
+ |  print_dyn (Findlib.Config.to_dyn conf);
+-|  [%expect
+-|    {|
+-|    { vars =
+-|        map
+-|          { "FOO_BAR" :
+-|              { set_rules =
+-|                  [ { preds_required = set { "env"; "tlc" }
+-|                    ; preds_forbidden = set {}
+-|                    ; value = "my variable"
+-|                    }
+-|                  ]
+-|              ; add_rules = []
+-|              }
+-|          }
+-|    ; preds = set { "tlc" }
+-|    } |}];
++|  [%expect.unreachable];
+-|  print_dyn (Env.to_dyn (Findlib.Config.env conf));
+-|  [%expect {| map { "FOO_BAR" : "my variable" } |}]
++|  print_dyn (Env.to_dyn (Findlib.Config.env conf));
++|  [%expect.unreachable]
++|[@@expect.uncaught_exn {|
++|  ( "Error: ocamlfind toolchain tlc isn't defined in\\
++|   \\n/Users/roland/Documents/code/dune/../unit-tests/findlib-db/../toolchain.d\\
++|   \\n(context: <context>)\\
++|   \\n") |}]
 `;
 
 /**

--- a/vscode-ocaml-expect-inline.code-workspace
+++ b/vscode-ocaml-expect-inline.code-workspace
@@ -20,6 +20,6 @@
             "Unop",
             "VSIX"
         ],
-        "expectppx.dunePath": "_opam/bin/dune"
+        "expectppx.dunePath": "./dune.exe"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,7 +399,7 @@
     jszip "^3.10.1"
     semver "^7.3.8"
 
-"@vscode/vsce@^2.18.0":
+"@vscode/vsce@^2.15.0", "@vscode/vsce@^2.18.0":
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/@vscode/vsce/-/vsce-2.18.0.tgz#9f40bf8e7df084a36844b9dadf5c277265c9fbd6"
   integrity sha512-tUA3XoKx5xjoi3EDcngk0VUYMhvfXLhS4s7CntpLPh1qtLYtgSCexTIMUHkCy6MqyozRW98bdW3a2yHPEADRnQ==
@@ -713,6 +713,11 @@ chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 clean-stack@^4.0.0:
   version "4.2.0"
@@ -1251,6 +1256,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
+follow-redirects@^1.14.6:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
@@ -1511,6 +1521,13 @@ is-binary-path@~2.1.0:
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
 
 is-core-module@^2.5.0:
   version "2.11.0"
@@ -1963,6 +1980,18 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+ovsx@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/ovsx/-/ovsx-0.8.0.tgz#e41dffaa8b6230a684e041c1cfe00d5f5b31344d"
+  integrity sha512-W1U7lgBIbhSB1DcqyGKeenKzmwWYY78SkWd+BUKKyLyqN6w39Uekdr0PKAM7dyBGb0JLtLE7d86A1jJVn8bEng==
+  dependencies:
+    "@vscode/vsce" "^2.15.0"
+    commander "^6.1.0"
+    follow-redirects "^1.14.6"
+    is-ci "^2.0.0"
+    leven "^3.1.0"
+    tmp "^0.2.1"
 
 p-limit@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
- No need to run all tests at startup or refresh. Use the `-list-test-names` argument of the inline test runners.
- Disable ANSI color escape sequences in output of test failures.
- Update the documentation.
- Remove ANSI escape sequences from test fixtures.
- Add yarn target for the Open VSX Registry.